### PR TITLE
 fixed broken link to betterspecs.org

### DIFF
--- a/docs/11_unit_tests.md
+++ b/docs/11_unit_tests.md
@@ -6,7 +6,7 @@
 * Use to test logic of cookbooks.
 * Just having it present catches compilation errors.
 * [github.com/sethvargo/chefspec](https://github.com/sethvargo/chefspec) has lots of examples.
-* [betterspecs.org](https://betterspecs.org) for thoughts on better unit testing.
+* [betterspecs.org](http://betterspecs.org) for thoughts on better unit testing.
 * It can help to have the Coverage report in your `spec_helper.rb`.
 ```ruby
 at_exit { ChefSpec::Coverage.report! }


### PR DESCRIPTION
Broken link to betterspecs.org was fixed on `11_unit_tests.md`.
Docs were pointing to `https` but betterspecs.org doesn't support it.